### PR TITLE
fix: expression errors

### DIFF
--- a/src/components/project_cqi/page_map/MapSourceCqi.tsx
+++ b/src/components/project_cqi/page_map/MapSourceCqi.tsx
@@ -17,7 +17,7 @@ export const MapSourceCqi = () => {
   // console.log(map.current?.getStyle())
 
   const userFilterGroups: {
-    [group: string]: ['in', string, ...(string | number)[]][]
+    [group: string]: ['in', string | [string, string], ['literal', (string | number)[]]][]
   } = {}
   const filters = filterParamsObject(params.filters)
   const flatLayerGroups = Object.values(legendByGroups)
@@ -32,7 +32,7 @@ export const MapSourceCqi = () => {
       if (filterConfig) {
         userFilterGroups[groupKey!] = [
           ...(userFilterGroups[groupKey!] || []),
-          ['in', filterConfig.key, ...filterConfig.values],
+          ['in', ['get', filterConfig.key], ['literal', filterConfig.values]],
         ]
       }
     })
@@ -60,7 +60,9 @@ export const MapSourceCqi = () => {
               wrapFilterWithAll([
                 ...userFilterExpression,
                 ...(layer.filter ? layer.filter : []),
-                ['in', 'id', ...mapDataIds],
+                ...(mapDataIds.length > 0
+                  ? [['in', ['get', 'id'], ['literal', mapDataIds]]]
+                  : [['literal', false]]),
               ]) as FilterSpecification
             }
           />

--- a/src/components/project_cqi/page_map/MapSourceCqi.tsx
+++ b/src/components/project_cqi/page_map/MapSourceCqi.tsx
@@ -17,7 +17,7 @@ export const MapSourceCqi = () => {
   // console.log(map.current?.getStyle())
 
   const userFilterGroups: {
-    [group: string]: ['in', string | [string, string], ['literal', (string | number)[]]][]
+    [group: string]: ['in', string | ['get', string], ['literal', (string | number)[]]][]
   } = {}
   const filters = filterParamsObject(params.filters)
   const flatLayerGroups = Object.values(legendByGroups)
@@ -60,9 +60,7 @@ export const MapSourceCqi = () => {
               wrapFilterWithAll([
                 ...userFilterExpression,
                 ...(layer.filter ? layer.filter : []),
-                ...(mapDataIds.length > 0
-                  ? [['in', ['get', 'id'], ['literal', mapDataIds]]]
-                  : [['literal', false]]),
+                ...(mapDataIds.length ? [['in', ['get', 'id'], ['literal', mapDataIds]]] : []),
               ]) as FilterSpecification
             }
           />


### PR DESCRIPTION
As previously discussed a had a look at the expression errors in the console. All errors were around using the `in` expression. Spec wants us to use it [as described](https://maplibre.org/maplibre-style-spec/expressions/#in):
```
["in", value, value]: boolean
```
So spreading the last value into it, actually shouldn't work, maybe that's an old spec? Also the array values need to be a `literal` and the `properties` should always need a `get` – maybe also some old spec?

After all, `in` doesn't feel quite right to me for comparing the `filter_usable` which seems to be kinda boolean `0` or `1` where a `==` would feel more fitting. But maybe that's due to the structure of the `filterConfig`. I'm not 100% confident my changes didn't brake anything else.